### PR TITLE
Need to register proper plugin pathname

### DIFF
--- a/lib/refinerycms-news.rb
+++ b/lib/refinerycms-news.rb
@@ -4,9 +4,17 @@ require File.expand_path('../news', __FILE__)
 module Refinery
   module News
 
+    class << self
+      attr_accessor :root
+      def root
+	@root ||= Pathname.new(File.expand_path('../../', __FILE__))	
+      end
+    end
+
     class Engine < Rails::Engine
       config.after_initialize do
         Refinery::Plugin.register do |plugin|
+	  plugin.pathname = root
           plugin.name = "refinerycms_news"
           plugin.menu_match = /(admin|refinery)\/news(_items)?$/
           plugin.url = {:controller => '/admin/news_items', :action => 'index'}


### PR DESCRIPTION
So, need to register the plugin pathname or the rake override tasks don't work.  This commit does it like the pages engine, so I hope it's the proper way.

Thanks,
Glenn
