### PR TITLE
In all locales it's 'body' not 'content'

### DIFF
--- a/app/views/admin/news_items/_form.html.erb
+++ b/app/views/admin/news_items/_form.html.erb
@@ -27,8 +27,8 @@
   </div>
 
   <div class='field'>
-    <%= f.label :content %>
-    <%= f.text_area :content, :rows => "20", :class => "wymeditor widest" %>
+    <%= f.label :body %>
+    <%= f.text_area :body, :rows => "20", :class => "wymeditor widest" %>
   </div>
 
   <%= render :partial => "/shared/admin/form_actions",


### PR DESCRIPTION
In all locales (or at least in en.yml) there is:
  activerecord:
    attributes:
      news_item:
        body: Body

But in admin's form partial it used as 'content':
<%= f.label :content %>

Therefore it won't be translated when the partial is rendered.
