### PR TITLE
refinerycms-news did not have a valid gemspec

### DIFF
--- a/refinerycms-news.gemspec
+++ b/refinerycms-news.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     'app/models/refinery',
     'app/models/refinery/news',
     'app/models/refinery/news/item.rb',
-    'app/models/refinery/news_item.rb',
+    'app/models/refinery/item.rb',
     'app/views',
     'app/views/refinery',
     'app/views/refinery/news',


### PR DESCRIPTION
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["app/models/refinery/news_item.rb"] are not files
