### PR TITLE
Enable refinery-news to be used with refinery-search

### DIFF
--- a/app/models/refinery/news/item.rb
+++ b/app/models/refinery/news/item.rb
@@ -33,6 +33,10 @@ module Refinery
         self.class.previous(self).first
       end
 
+      def url
+        "/news/#{slug}"
+      end
+
       class << self
         def by_archive(archive_date)
           where(['publish_date between ? and ?', archive_date.beginning_of_month, archive_date.end_of_month])


### PR DESCRIPTION
A url method is required if refinery-news is to be used in conjunction with refinery-search.
