### PR TITLE
Specify regex for year and month within archive route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Refinery::Core::Engine.routes.draw do
   namespace :news do
     root :to => "items#index"
-    get 'archive/:year(/:month)', :to => 'items#archive', :as => 'items_archive'
+    get 'archive/:year(/:month)', :to => 'items#archive', :as => 'items_archive', :constraints => { :year => /\d{4}/, :month => /\d{1,2}/ }
     resources :items, :only => [:show, :index], :path => ''
   end
 


### PR DESCRIPTION
Instead of throwing an exception when a route like /news/archive/2012/whatever is accessed, Rails will return a 404 since the route won't match anymore.

Please let me know if my regex is too specific. I assumed years would be four numbers and months would be two numbers, and everything else would not match.
