### PR TITLE
Use translated scope in Archive because we should

### DIFF
--- a/app/controllers/refinery/news/items_controller.rb
+++ b/app/controllers/refinery/news/items_controller.rb
@@ -16,10 +16,10 @@ module Refinery
       def archive
         if params[:month].present?
           @archive_date = Time.parse("#{params[:month]}/#{params[:year]}")
-          @items = Refinery::News::Item.live.by_archive(@archive_date).page(params[:page])
+          @items = Refinery::News::Item.live.translated.by_archive(@archive_date).page(params[:page])
         else
           @archive_date = Time.parse("01/#{params[:year]}")
-          @items = Refinery::News::Item.live.by_year(@archive_date).page(params[:page])
+          @items = Refinery::News::Item.live.translated.by_year(@archive_date).page(params[:page])
         end
       end
 

--- a/spec/controllers/refinery/news/items_controller_spec.rb
+++ b/spec/controllers/refinery/news/items_controller_spec.rb
@@ -35,7 +35,7 @@ module Refinery
       describe "#archive" do
         context "when month is present" do
           it "assigns archive_date and items" do
-            Refinery::News::Item.stub_chain(:live, :by_archive, :page).and_return(item)
+            Refinery::News::Item.stub_chain(:live, :translated, :by_archive, :page).and_return(item)
             get :archive, :month => 05, :year => 1999
             assigns(:archive_date).should eq(Time.parse("05/1999"))
             assigns(:items).should eq(item)
@@ -44,7 +44,7 @@ module Refinery
 
         context "when month isnt present" do
           it "assigns archive_date and items" do
-            Refinery::News::Item.stub_chain(:live, :by_year, :page).and_return(item)
+            Refinery::News::Item.stub_chain(:live, :translated, :by_year, :page).and_return(item)
             get :archive, :year => 1999
             assigns(:archive_date).should eq(Time.parse("01/1999"))
             assigns(:items).should eq(item)


### PR DESCRIPTION
I came across this because I get an exception `"ActionView::Template::Error: undefined method 'html_safe' for nil:NilClass"`
which is caused by `truncate(...)` returning nil on line https://github.com/refinery/refinerycms-news/blob/master/app/helpers/refinery/news/items_helper.rb#L24

Easily reproducable by having 2 locales and create a news item in one language but not the 2nd, then switching to the 2nd locale to view the Archive page, it would crash because it loads some news items with 'item.body == nil' (causing `truncate(item.body)` to be nil).

There are validations for News::Item so we just need to make sure to load only valid records. This is also consistent with the rest of the refinery/news/items_controller.rb file

The commit in this pull can also be cherry-picked into the `2-0-stable` branch
