### PR TITLE
update to match new default_parts hash

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,7 @@ if defined?(::Refinery::Page)
     )
 
     ::Refinery::Pages.default_parts.each do |default_page_part|
-      page.parts.create(:title => default_page_part, :body => nil)
+      page.parts.create(title: default_page_part[:title], slug: default_page_part[:slig], body: nil)
     end
   end
 end


### PR DESCRIPTION
fixes page part creation from seeds.rb. Matches now new page part convention: {title: '', slug: ''}